### PR TITLE
Update Webpack Config and Documentation

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -25,7 +25,6 @@ jobs:
     - name: npm install, build, and test
       run: |
         npm ci
-        npm run build --if-present
         npm test
       env:
         CI: true

--- a/README.md
+++ b/README.md
@@ -37,8 +37,17 @@ primarily used for developers who want information at a glance.
 
 The extension can be found at [this]() link on the Chrome Web Store. 
 
-If you wish to contribute to this project, installation is simple. After cloning the repository, install the neccessary 
-packages.
+If you wish to contribute to this project, installation is simple. You will however need a few dependencies. This README
+ will assume that you are developing on Linux. 
+ 
+### Dependencies
+
+ - [Git]()
+ - [The Node Package Manager or NPM]()
+ - [Webpack]()
+ 
+ 
+After installing the above and cloning the repository, install the neccessary packages.
 
 `npm install`
 
@@ -47,13 +56,16 @@ You can build the extension by running the command
 `npm run build`
 
 in your terminal. If you use Webstorm for web development, configuration files have been provided for you. Simply click 
-the run button and the extension will build.
+the run button and the extension will build. 
 
 After a successful build, the extension files will exist in a new dist directory. In Chrome, navigate to 
 [your extensions directory](chrome://extensions/). Slide the developer switch in the top right of the screen if you 
 haven't already. Load the dist folder through the unpacked loader. The extension will load.
 
-After making changes, you will need to click the reload button on the extension to view your changes.
+Webpack is set to watch mode, which allows dynamic reloading of source 
+materials. If you edit the source files, Webpack will automatically rebundle the files into the dist directory for you. 
+In order to reload the extension following changes, you will still need to refresh the extension in Chrome by clicking 
+the refresh button in the menu.
 
 ## Issues and Pull Requests
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,13 +3,9 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 
 module.exports = {
-    watch: false,
-    mode: 'development',
+    devtool: 'inline-source-map',
     entry: './src/index.js',
-    output: {
-        filename: 'index.js',
-        path: path.resolve(__dirname, 'dist')
-    },
+    mode: 'development',
     module: {
         rules: [
             {
@@ -23,11 +19,20 @@ module.exports = {
             }
         ]
     },
+    optimization: {
+        splitChunks: {
+            chunks: 'all',
+        },
+    },
+    output: {
+        filename: 'index.js',
+        path: path.resolve(__dirname, 'dist')
+    },
     plugins: [
         new CleanWebpackPlugin(),
         new HtmlWebpackPlugin({
             template: 'src/index.html'
         })
     ],
-    devtool: 'cheap-module-source-map'
+    watch: true
 };


### PR DESCRIPTION
Update Webpack Config to support watch reloading. Update README to include new documentation on this subject. Also add dependencies to README.

## TRY IT OUT

This feature is really nice. After running npm run build, Webpack will automatically watch the source files and recompile the extension into the dist folder for you on change! Therefore, leave the terminal with npm run build running! Then after making changes, simply refresh the extension in Chrome and it should be updated!